### PR TITLE
Fix JWT library version mismatch

### DIFF
--- a/pyzoom/_base.py
+++ b/pyzoom/_base.py
@@ -159,4 +159,6 @@ class APIClientBase:
         payload = {"iss": key, "exp": int(time.time() + 3600)}
 
         token = jwt.encode(payload, secret, algorithm="HS256", headers=header)
-        return token.decode("utf-8")
+
+        # Compatibility between different versions of pyjwt (2.1.0 returns str).
+        return if isinstance(token, str) else token.decode("utf-8")

--- a/pyzoom/_base.py
+++ b/pyzoom/_base.py
@@ -161,4 +161,4 @@ class APIClientBase:
         token = jwt.encode(payload, secret, algorithm="HS256", headers=header)
 
         # Compatibility between different versions of pyjwt (2.1.0 returns str).
-        return if isinstance(token, str) else token.decode("utf-8")
+        return token if isinstance(token, str) else token.decode("utf-8")


### PR DESCRIPTION
When calling this library with the `pyjwt` version installed from pip by default (`2.1.0`), the `token` returned is a `str`, which means `decode` does not exist.

To support multiple versions of the `jwt` library, check the type of token returned and act accordingly.

Fixes issue 35:
https://github.com/licht1stein/pyzoom/issues/35