### PR TITLE
Fix #70 error handling breaking due to XML response from Zoom

### DIFF
--- a/pyzoom/_base.py
+++ b/pyzoom/_base.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 import logging
 import time
 from typing import Dict
@@ -46,13 +47,18 @@ class APIClientBase:
             return r
 
         try:
-            message = r.json()["_error"]["message"]
-        except KeyError:
-            message = r.json()
+            body = r.json()
+            try:
+                message = body["_error"]["message"]
+            except KeyError:
+                message = body
+        except JSONDecodeError:
+            body = r.text
+            message = body
 
         logging.error(f"Unsuccessful request to {r.url}: [{r.status_code}] {message}")
 
-        logging.debug(f"Full response: {r.json()}")
+        logging.debug(f"Full response: {body}")
         logging.debug(f"Headers: {r.headers}")
         logging.debug(f"Params: {query}")
         logging.debug(f"Body: {body}")


### PR DESCRIPTION
Attempts to fix #70. It’s not the simplest to read but does fix the issue. Here is the test code I used for this:

```python
from datetime import datetime

from pyzoom import ZoomClient

client = ZoomClient("[…]", "[…]")

client.meetings.create_meeting("Test",
        start_time=datetime.now().isoformat(),
        duration_min=50,
        password="12345678901234567890")
```

Output:

```text
ERROR:root:Unsuccessful request to https://api.zoom.us/v2/users/me/meetings: [400] <?xml version="1.0" encoding="UTF-8" standalone="yes"?><result><code>300</code><message>Validation Failed.</message><errors><field>password</field><message>Password provided does not match the password requirement settings set for this account. The password must follow these rules: [Password can only have a maximum 10 characters.].</message></errors></result>
Traceback (most recent call last):
  File "example.py", line 10, in <module>
    password="12345678901234567890")
  File "pyzoom/pyzoom/_client.py", line 50, in create_meeting
    response = self._client.post(endpoint, body=body)
  File "pyzoom/pyzoom/_base.py", line 113, in post
    raise_on_error=raise_on_error,
  File "pyzoom/pyzoom/_base.py", line 72, in make_request
    raise err.HTTP_ERRORS_MAP[r.status_code](message)
pyzoom.err.BadRequest: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><result><code>300</code><message>Validation Failed.</message><errors><field>password</field><message>Password provided does not match the password requirement settings set for this account. The password must follow these rules: [Password can only have a maximum 10 characters.].</message></errors></result>
```