### PR TITLE
Zoom meeting update feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ client = ZoomClient.from_environment()
 
 ### Meetings
 
-#### Create meeting and add registrant
+#### Create meeting, Update meeting and add registrant
 ```python
 from pyzoom import ZoomClient
 from datetime import datetime as dt

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ client = ZoomClient.from_environment()
 # Creating a meeting
 meeting = client.meetings.create_meeting('Auto created 1', start_time=dt.now().isoformat(), duration_min=60, password='not-secure')
 
+# Update a meeting
+meeting = client.meetings.update_meeting('Auto updated 1', meeting_id = meeting.id ,start_time=dt.now().isoformat(), duration_min=60,password='not-secure')
 
 # Adding registrants
 client.meetings.add_meeting_registrant(meeting.id, first_name='John', last_name='Doe', email='john.doe@example.com')

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ client = ZoomClient.from_environment()
 
 ### Meetings
 
-#### Create meeting, Update meeting and add registrant
+#### Create meeting, update meeting and add registrant
 ```python
 from pyzoom import ZoomClient
 from datetime import datetime as dt

--- a/pyzoom/_client.py
+++ b/pyzoom/_client.py
@@ -23,7 +23,10 @@ class MeetingsComponent:
     def get_meeting(self, meeting_id: int) -> schemas.ZoomMeeting:
         endpoint = f"/meetings/{meeting_id}"
         return schemas.ZoomMeeting(**self._client.get(endpoint).json())
-
+    """
+    LineNumber:49 can be without Conversion to dict. Which may give user 
+    an advantage to pass dictionary while creating the meeting in parameter 'settings'.
+    """
     def create_meeting(
         self,
         topic: str,
@@ -49,6 +52,39 @@ class MeetingsComponent:
         }
         response = self._client.post(endpoint, body=body)
         return schemas.ZoomMeeting(**response.json())
+
+    """
+    UpdateMeeting Should be passed with same parameters as create_meeting but
+    meeting_id is an additional requirement when we wish to modify the meeting.
+    In the return from we get a StatusCode and empty dictionary.
+    """
+
+    def update_meeting(
+        self,
+        topic: str,
+        *,
+        start_time: str,
+        duration_min: int,
+        timezone: str = None,
+        type_: int = 2,
+        password: str = None,
+        settings: schemas.ZoomMeetingSettings = None,
+        meeting_id: int,
+    ) -> schemas.ZoomMeeting:
+        endpoint = f"/meetings/{meeting_id}"
+        body = {
+            "topic": topic,
+            "type": type_,
+            "start_time": start_time,
+            "duration": duration_min,
+            "timezone": timezone or self.timezone,
+            "password": password or shortuuid.random(6),
+            "settings": settings.dict() 
+            if settings
+            else schemas.ZoomMeetingSettings.default_settings().dict(),
+        }
+        response = self._client.patch(endpoint, body=body)
+        return {}
 
     def delete_meeting(self, meeting_id: int) -> bool:
         endpoint = f"/meetings/{meeting_id}"


### PR DESCRIPTION
## Feature Description

Update zoom meeting feature enables users to update an already created meeting by providing necessary parameters. The only additional requirement while updating a meeting is MeetinID. 

```python
from pyzoom import ZoomClient
from datetime import datetime as dt

client = ZoomClient.from_environment()

# Creating a meeting
meeting = client.meetings.create_meeting('Auto created 1', start_time=dt.now().isoformat(), duration_min=60, password='not-secure')

# Update a meeting
meeting = client.meetings.update_meeting('Auto updated 1', meeting_id = meeting.id ,start_time=dt.now().isoformat(), duration_min=60,password='not-secure')
```