### PR TITLE
Relaxing necessity of missing response variables

### DIFF
--- a/pyzoom/schemas.py
+++ b/pyzoom/schemas.py
@@ -72,7 +72,7 @@ class ZoomMeetingShort(MyZoomBase):
     host_id: str
     topic: str
     type: int
-    start_time: str
+    start_time: Optional[str] = None
     duration: int
     timezone: str
     created_at: str
@@ -92,11 +92,12 @@ class ZoomMeeting(ZoomMeetingShort):
 
 
 class ZoomMeetingShortList(MyZoomBase):
-    page_count: int
-    page_number: int
+    page_count: Optional[int] = None
+    page_number: Optional[int] = None
     page_size: int
     total_records: int
     meetings: List[ZoomMeetingShort]
+    next_page_token: Optional[str] = None
 
     def filter_by_topic(self, text: str) -> List[ZoomMeetingShort]:
         return [m for m in self.meetings if text.lower() in m.topic.lower()]


### PR DESCRIPTION
I was using this library to list the attendees at my meetings, and even though Zoom's API (https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetings) said that there would be a page count etc, these fields were not always present.

After I made these modifications, I was able to get this example running: https://github.com/owen9825/zoom_attendance