### PR TITLE
Switch to PyPI API token publishing

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -63,4 +63,4 @@ jobs:
       run: pip install poetry
     - name: Upload to pypi.org
       run: |
-        poetry publish --build -u ${{ secrets.PYPI_USER }} -p ${{ secrets.PYPI_PASSWORD }}
+        poetry publish --build -u __token__ -p ${{ secrets.PYPI_APITOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyzoom"
-version = "1.0.7"
+version = "1.0.8"
 description = "Python wrapper for Zoom Video API"
 authors = ["MB <mb@blaster.ai>"]
 license = "MIT"

--- a/pyzoom/schemas.py
+++ b/pyzoom/schemas.py
@@ -26,7 +26,7 @@ class ZoomMeetingSettings(MyZoomBase):
     watermark: bool
     use_pmi: bool
     approval_type: Literal[0, 1, 2]
-    registration_type: Optional[Literal[1, 2, 3]]
+    registration_type: Optional[Literal[1, 2, 3]] = None
     audio: Literal["voip", "telephony", "both"]
     auto_recording: Literal["local", "cloud", "none"]
     enforce_login: bool


### PR DESCRIPTION
I also found a tiny bug with the pydantic validation with `registration_type` (related to #154 and #155)

@licht1stein We need you to create the token and name it `PYPI_APITOKEN` in Github.
Thanks.