### PR TITLE
Added inherited init to RequestHandler to properly assign authorization_code

### DIFF
--- a/pyzoom/oauth.py
+++ b/pyzoom/oauth.py
@@ -121,6 +121,10 @@ def oauth_wizard(client_id=None, client_secret=None, port=3000, redirect_uri=Non
         client_secret = getpass("Client Secret: ")
 
     class RequestHandler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, request, client_address, server, *, directory = None):
+            super().__init__(request, client_address, server, directory=directory)
+            self.server.authorization_code = None
+        
         def do_GET(self):
             self.send_response(200)
             self.end_headers()


### PR DESCRIPTION
When calling `oauth_wizard()`, I kept getting `AttributeError: 'HTTPServer' object has no attribute 'authorization_code'`. So after some investigating, it appears that the `BaseRequestHandler` class doesn't have an `authorization_code` attribute. So, I just added an inherited initializer to the `RequestHandler` class to add the authorization_code attribute.